### PR TITLE
Added version specific partials

### DIFF
--- a/src/lib/Xrm.Oss.UnitOfWork/UpdateContext.2016.cs
+++ b/src/lib/Xrm.Oss.UnitOfWork/UpdateContext.2016.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
+
+namespace Xrm.Oss.UnitOfWork
+{
+    public partial class UpdateContext<T> : IDisposable where T : Entity
+    {
+        public bool AddToTransaction(ExecuteTransactionRequest transaction)
+        {
+            if (transaction.Requests == null)
+            {
+                transaction.Requests = new OrganizationRequestCollection();
+            }
+
+            var updateRequest = GetUpdateRequest();
+
+            if (updateRequest == null)
+            {
+                return false;
+            }
+
+            transaction.Requests.Add(updateRequest);
+            return true;
+        }
+    }
+}

--- a/src/lib/Xrm.Oss.UnitOfWork/UpdateContext.cs
+++ b/src/lib/Xrm.Oss.UnitOfWork/UpdateContext.cs
@@ -213,6 +213,24 @@ namespace Xrm.Oss.UnitOfWork
             return null;
         }
 
+        public bool AddToExecuteMultiple(ExecuteMultipleRequest executeMultiple)
+        {
+            if (executeMultiple.Requests == null)
+            {
+                executeMultiple.Requests = new OrganizationRequestCollection();
+            }
+
+            var updateRequest = GetUpdateRequest();
+
+            if (updateRequest == null)
+            {
+                return false;
+            }
+
+            executeMultiple.Requests.Add(updateRequest);
+            return true;
+        }
+
         public void Dispose()
         {
             Dispose(true);


### PR DESCRIPTION
This should allow for version specific features.
For example there should be a separate 2016 / 365 package, that adds some shortcut functions for adding update requests to transactions.
We can't include this in the normal package, as it would not build anymore in < 2016 projects.
Each nuget package has to include the base UpdateContext and the version specific partial class.